### PR TITLE
Make Function Call "Italic"

### DIFF
--- a/Material Peacock.icls
+++ b/Material Peacock.icls
@@ -994,6 +994,7 @@
     <option name="PHP_FUNCTION_CALL">
       <value>
         <option name="FOREGROUND" value="ff5d38" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">


### PR DESCRIPTION
Function calls used to be italic before my https://github.com/daylerees/material-peacock/pull/6 PR. After that italic behaviour has been disappeared.
This PR makes functions calls italic.
